### PR TITLE
Don't call createPVectorMethod on toString

### DIFF
--- a/processing.js
+++ b/processing.js
@@ -2039,8 +2039,12 @@
         };
       }
 
+      // Create the static methods of PVector automatically
+      // We don't do toString because it causes a TypeError 
+      //  when attempting to stringify PVector
       for (var method in PVector.prototype) {
-        if (PVector.prototype.hasOwnProperty(method) && !PVector.hasOwnProperty(method)) {
+        if (PVector.prototype.hasOwnProperty(method) && !PVector.hasOwnProperty(method) &&
+              method !== "toString") {
           PVector[method] = createPVectorMethod(method);
         }
       }


### PR DESCRIPTION
This is what was responsible for output.js having a TypeError when attempting to stringify PVector.

Please review @jeresig 

I have a branch that makes same changes in stubs file.
