### PR TITLE
Don't round coordinates on lines, rectangles, and points in smooth mode

### DIFF
--- a/processing.js
+++ b/processing.js
@@ -12020,8 +12020,10 @@
         return;
       }
 
-      x = Math.round(x);
-      y = Math.round(y);
+      if (!renderSmooth) {
+        x = Math.round(x);
+        y = Math.round(y);
+      }
       curContext.fillStyle = p.color.toString(currentStrokeColor);
       isFillDirty = true;
       // Draw a circle for any point larger than 1px
@@ -13565,10 +13567,12 @@
       if (!doStroke) {
         return;
       }
-      x1 = Math.round(x1);
-      x2 = Math.round(x2);
-      y1 = Math.round(y1);
-      y2 = Math.round(y2);
+      if (!renderSmooth) {
+        x1 = Math.round(x1);
+        x2 = Math.round(x2);
+        y1 = Math.round(y1);
+        y2 = Math.round(y2);
+      }
       // A line is only defined if it has different start and end coordinates.
       // If they are the same, we call point instead.
       if (x1 === x2 && y1 === y2) {
@@ -13924,10 +13928,12 @@
         y -= height / 2;
       }
 
-      x = Math.round(x);
-      y = Math.round(y);
-      width = Math.round(width);
-      height = Math.round(height);
+      if (!renderSmooth) {
+        x = Math.round(x);
+        y = Math.round(y);
+        width = Math.round(width);
+        height = Math.round(height);
+      }
       if (tl !== undef) {
         roundedRect$2d(x, y, width, height, tl, tr, br, bl);
         return;


### PR DESCRIPTION
I was experimented with drawing dashed lines on KA using processing, but they looked wobbly.  The cause of this wobbliness is that processing rounds the coordinates before drawing.  Here's some screenshots:

Before:
![screen shot 2014-10-13 at 11 10 45 pm](https://cloud.githubusercontent.com/assets/1044413/4688318/81abbf5c-5670-11e4-87d4-be816c1f01af.png)

After:
![screen shot 2014-10-14 at 9 21 12 pm](https://cloud.githubusercontent.com/assets/1044413/4688319/87a09b94-5670-11e4-9512-bf441990b7e1.png)

This pull request enables the behaviour in the second screenshot only after users call `smooth()`.  Since this command isn't advertised it should affect very few users.

The reason why I want to draw nice look dashed lines is because I'd like to draw some nice 3D line art diagrams like this:
![screen shot 2014-10-17 at 8 49 36 pm](https://cloud.githubusercontent.com/assets/1044413/4688340/7a8d7c14-5671-11e4-844f-00c401bc50a8.png)

It would be nice if processing-js exposed a way to use the canvas' `setLineDash` command... maybe as a live-editor extension.  Thoughts?
