### PR TITLE
Guard against x, y, z being set to undefined.  

### DIFF
--- a/processing.js
+++ b/processing.js
@@ -1881,9 +1881,9 @@
                      v.y || v[1] || 0,
                      v.z || v[2] || 0);
           } else {
-            this.x = v;
-            this.y = y;
-            this.z = z;
+            this.x = v || 0;
+            this.y = y || 0;
+            this.z = z || 0;
           }
         },
         get: function() {


### PR DESCRIPTION
Required to fix https://github.com/Khan/live-editor/issues/230.