### PR TITLE
Round font sizes to the nearest tenth.

### DIFF
--- a/processing.js
+++ b/processing.js
@@ -16321,6 +16321,8 @@
      */
     p.textSize = function(size) {
       if (size !== curTextSize) {
+        // round size to the nearest tenth so that we don't explode the cache
+        size = Math.round(10 * size) / 10;
         curTextFont = PFont.get(curFontName, size);
         curTextSize = size;
         // recache metrics


### PR DESCRIPTION
Summary:
Using random font sizes explodes memory use because processing.js
caches PFont instances using the the font name and size as the cache
key.  Because the size is random, none of the cached font instances
are reused because we keep caching them.  A better solution would be
to use a LRU (Least Recently Used) cache like jscache.  If this continues
to be a problem we can look into changing the cache system.

Test Plan:
- open demos/simple/index.html in live-editor (in Firefox)  and type the following code:
```
    draw = function() {
        textSize(random(10,30));
    };
```
- check memory use using `top` or Activity Monitor and very that it tops out around 2GB (as opposed to continually growing)

Auditors: pamela