### PR TITLE
Add lru cache to fix textSize memory leak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ Unsaved\ Document*
 *.swp
 *~
 *.pyc
+node_modules

--- a/LRUCache/LRUCache.js
+++ b/LRUCache/LRUCache.js
@@ -17,7 +17,9 @@ function LRUCache(maxSize) {
   this.cache = {}; // key => val
   this.useIndex = {}; // use index => key
   this.useReverse = {}; // key => use index
-  this.mostRecent = 0;
+  // this will be incremented to 0 for the first item added, making
+  // leastRecent === mostRecent
+  this.mostRecent = -1;
   this.leastRecent = 0;
 }
 
@@ -39,7 +41,9 @@ LRUCache.prototype.get = function(key) {
   */
 LRUCache.prototype.set = function(key, val) {
   key = key + '';
-  this.size += 1;
+  if (!this.cache[key]) {
+    this.size += 1;
+  }
   this.cache[key] = val;
   this._makeMostRecent(key);
 
@@ -65,15 +69,17 @@ LRUCache.prototype._makeMostRecent = function (key) {
 LRUCache.prototype._pop = function () {
   while (this.leastRecent < this.mostRecent) {
     var oldKey = this.useIndex[this.leastRecent];
-    if (oldKey) {
-      delete this.useIndex[this.leastRecent];
-      delete this.useReverse[oldKey];
-      delete this.cache[oldKey];
+    if (!oldKey) {
       this.leastRecent += 1;
-      this.size -= 1;
-      return;
+      continue;
     }
+
+    delete this.useIndex[this.leastRecent];
+    delete this.useReverse[oldKey];
+    delete this.cache[oldKey];
     this.leastRecent += 1;
+    this.size -= 1;
+    return;
   }
 }
 

--- a/LRUCache/LRUCache.js
+++ b/LRUCache/LRUCache.js
@@ -1,0 +1,56 @@
+
+function LRUCache(maxSize) {
+  this.maxSize = maxSize || 100;
+  this.size = 0;
+  this.cache = {}; // key => val
+  this.useIndex = {}; // use index => key
+  this.useReverse = {}; // key => use index
+  this.mostRecent = -1;
+  this.leastRecent = -1;
+}
+
+LRUCache.prototype.get = function(key) {
+  key = key + '';
+  if (!this.cache[key]) {
+    return;
+  }
+  delete this.useIndex[this.useReverse[key]];
+
+  this._makeMostRecent(key);
+  return this.cache[key];
+};
+
+LRUCache.prototype.set = function(key, val) {
+  key = key + '';
+  this.size += 1;
+  this.cache[key] = val;
+  this._makeMostRecent(key);
+
+  if (this.size > this.maxSize) {
+    this._pop();
+  }
+};
+
+LRUCache.prototype._makeMostRecent = function (key) {
+  this.mostRecent += 1;
+  var newIndex = this.mostRecent;
+  this.useIndex[newIndex] = key;
+  this.useReverse[key] = newIndex;
+}
+
+LRUCache.prototype._pop = function () {
+  while (this.leastRecent < this.mostRecent) {
+    var oldKey = this.useIndex[this.leastRecent];
+    if (oldKey) {
+      delete this.useIndex[this.leastRecent];
+      delete this.useReverse[oldKey];
+      delete this.cache[oldKey];
+      this.leastRecent += 1;
+      this.size -= 1;
+      return;
+    }
+    this.leastRecent += 1;
+  }
+}
+
+module.exports = LRUCache;

--- a/LRUCache/LRUCache.js
+++ b/LRUCache/LRUCache.js
@@ -12,7 +12,7 @@
  */
 
 function LRUCache(maxSize) {
-  this.maxSize = maxSize || 100;
+  this.maxSize = maxSize;
   this.size = 0;
   this.cache = {}; // key => val
   this.useIndex = {}; // use index => key

--- a/LRUCache/LRUCache.js
+++ b/LRUCache/LRUCache.js
@@ -1,3 +1,15 @@
+/**
+ * This is a Least Recently Used Cache
+ *
+ * When the max size is reached, then the least recently used item is dropped.
+ *
+ * This is tracked by having a "use index", which is a number indicating how
+ * recently a given item was accessed. The closer the "use index" is to
+ * "mostRecent", the more recently is was used.
+ *
+ * When an item is accessed (via .get()) it's "use index" gets updated to be
+ * the new "most recent".
+ */
 
 function LRUCache(maxSize) {
   this.maxSize = maxSize || 100;
@@ -5,21 +17,26 @@ function LRUCache(maxSize) {
   this.cache = {}; // key => val
   this.useIndex = {}; // use index => key
   this.useReverse = {}; // key => use index
-  this.mostRecent = -1;
-  this.leastRecent = -1;
+  this.mostRecent = 0;
+  this.leastRecent = 0;
 }
 
+/**
+  * Get a value from the cache, returning undefined for an unknown key
+  */
 LRUCache.prototype.get = function(key) {
   key = key + '';
   if (!this.cache[key]) {
     return;
   }
-  delete this.useIndex[this.useReverse[key]];
-
   this._makeMostRecent(key);
   return this.cache[key];
 };
 
+/**
+  * Set a value in the cache. If the max size is reached, the least recently
+  * used item will be popped off.
+  */
 LRUCache.prototype.set = function(key, val) {
   key = key + '';
   this.size += 1;
@@ -32,6 +49,13 @@ LRUCache.prototype.set = function(key, val) {
 };
 
 LRUCache.prototype._makeMostRecent = function (key) {
+  var current = this.useReverse[key];
+  if (current === this.mostRecent) {
+    return;
+  } else if (current) {
+    delete this.useIndex[current];
+  }
+
   this.mostRecent += 1;
   var newIndex = this.mostRecent;
   this.useIndex[newIndex] = key;

--- a/LRUCache/package.json
+++ b/LRUCache/package.json
@@ -1,0 +1,7 @@
+{
+  "devDependencies": {
+    "babel-core": "^5.8.23",
+    "chai": "^3.2.0",
+    "mocha": "^2.3.0"
+  }
+}

--- a/LRUCache/run.js
+++ b/LRUCache/run.js
@@ -1,0 +1,4 @@
+
+require('babel-core/register');
+require('./test');
+

--- a/LRUCache/test.js
+++ b/LRUCache/test.js
@@ -1,0 +1,57 @@
+
+var {expect} = require('chai');
+var LRUCache = require('./LRUCache');
+
+describe('Cache', () => {
+  it('should initialize', () => {
+    var cache = new LRUCache();
+  });
+
+  it('should add an item', () => {
+    var cache = new LRUCache();
+    cache.set('one', 20);
+    expect(cache.get('one')).to.equal(20);
+    expect(cache.size).to.equal(1);
+  });
+
+  it('should pop', () => {
+    var cache = new LRUCache(2);
+    cache.set('one', 20);
+    cache.set('two', 30);
+    cache.set('three', 40);
+    expect(cache.get('three')).to.equal(40);
+    expect(cache.get('two')).to.equal(30);
+    expect(cache.get('one')).to.not.be.ok;
+  });
+
+  it('should keep size limited', () => {
+    var cache = new LRUCache(20);
+    for (var i=0; i<100; i++) {
+      cache.set(i, 'num' + i);
+    }
+    expect(cache.size).to.equal(20);
+    for (var i=80; i<100; i++) {
+      expect(cache.get(i)).to.equal('num' + i);
+    }
+    // manually check size
+    var size = 0;
+    for (var name in cache.cache) {
+      size += 1;
+    }
+    expect(size).to.equal(20);
+  });
+
+  it('should keep used things around', () => {
+    var cache = new LRUCache(20);
+    for (var i=0; i<100; i++) {
+      cache.set(i, 'num' + i);
+      cache.get(42);
+    }
+    expect(cache.size).to.equal(20);
+    for (var i=81; i<100; i++) {
+      expect(cache.get(i)).to.equal('num' + i);
+    }
+    expect(cache.get(42)).to.equal('num42');
+  });
+});
+

--- a/LRUCache/test.js
+++ b/LRUCache/test.js
@@ -4,11 +4,11 @@ var LRUCache = require('./LRUCache');
 
 describe('Cache', () => {
   it('should initialize', () => {
-    var cache = new LRUCache();
+    var cache = new LRUCache(10);
   });
 
   it('should add an item', () => {
-    var cache = new LRUCache();
+    var cache = new LRUCache(10);
     cache.set('one', 20);
     expect(cache.get('one')).to.equal(20);
     expect(cache.size).to.equal(1);

--- a/LRUCache/test.js
+++ b/LRUCache/test.js
@@ -53,5 +53,17 @@ describe('Cache', () => {
     }
     expect(cache.get(42)).to.equal('num42');
   });
+
+  it('overwriting a key should not pop anything', () => {
+    var cache = new LRUCache(5);
+    for (var i=0; i<5; i++) {
+      cache.set(i, 'num' + i);
+    }
+    cache.set(0, 'num0');
+    cache.set(0, 'num0');
+    for (var i=0; i<5; i++) {
+      expect(cache.get(i)).to.equal('num' + i);
+    }
+  });
 });
 

--- a/processing.js
+++ b/processing.js
@@ -1405,7 +1405,7 @@
   */
 
   function LRUCache(maxSize) {
-    this.maxSize = maxSize || 100;
+    this.maxSize = maxSize;
     this.size = 0;
     this.cache = {}; // key => val
     this.useIndex = {}; // use index => key

--- a/processing.js
+++ b/processing.js
@@ -1410,7 +1410,9 @@
     this.cache = {}; // key => val
     this.useIndex = {}; // use index => key
     this.useReverse = {}; // key => use index
-    this.mostRecent = 0;
+    // this will be incremented to 0 for the first item added, making
+    // leastRecent === mostRecent
+    this.mostRecent = -1;
     this.leastRecent = 0;
   }
 
@@ -1432,7 +1434,9 @@
     */
   LRUCache.prototype.set = function(key, val) {
     key = key + '';
-    this.size += 1;
+    if (!this.cache[key]) {
+      this.size += 1;
+    }
     this.cache[key] = val;
     this._makeMostRecent(key);
 
@@ -1458,15 +1462,17 @@
   LRUCache.prototype._pop = function () {
     while (this.leastRecent < this.mostRecent) {
       var oldKey = this.useIndex[this.leastRecent];
-      if (oldKey) {
-        delete this.useIndex[this.leastRecent];
-        delete this.useReverse[oldKey];
-        delete this.cache[oldKey];
+      if (!oldKey) {
         this.leastRecent += 1;
-        this.size -= 1;
-        return;
+        continue;
       }
+
+      delete this.useIndex[this.leastRecent];
+      delete this.useReverse[oldKey];
+      delete this.cache[oldKey];
       this.leastRecent += 1;
+      this.size -= 1;
+      return;
     }
   }
 

--- a/processing.js
+++ b/processing.js
@@ -1392,23 +1392,44 @@
   ////////////////////////////////////////////////////////////////////////////
 
   /**
-   * A cache which has a limited size and removes the lease recently used
-   * items when that size is reached.
-   */
+  * This is a Least Recently Used Cache
+  *
+  * When the max size is reached, then the least recently used item is dropped.
+  *
+  * This is tracked by having a "use index", which is a number indicating how
+  * recently a given item was accessed. The closer the "use index" is to
+  * "mostRecent", the more recently is was used.
+  *
+  * When an item is accessed (via .get()) it's "use index" gets updated to be
+  * the new "most recent".
+  */
+
   function LRUCache(maxSize) {
     this.maxSize = maxSize || 100;
     this.size = 0;
     this.cache = {}; // key => val
     this.useIndex = {}; // use index => key
     this.useReverse = {}; // key => use index
-    this.mostRecent = -1;
-    this.leastRecent = -1;
+    this.mostRecent = 0;
+    this.leastRecent = 0;
   }
 
   /**
-   * Set a value in the cache. If the max size is reached, the least recently
-   * used item will be popped off.
-   */
+    * Get a value from the cache, returning undefined for an unknown key
+    */
+  LRUCache.prototype.get = function(key) {
+    key = key + '';
+    if (!this.cache[key]) {
+      return;
+    }
+    this._makeMostRecent(key);
+    return this.cache[key];
+  };
+
+  /**
+    * Set a value in the cache. If the max size is reached, the least recently
+    * used item will be popped off.
+    */
   LRUCache.prototype.set = function(key, val) {
     key = key + '';
     this.size += 1;
@@ -1420,21 +1441,14 @@
     }
   };
 
-  /**
-   * Get a value from the cache, returning undefined for an unknown key
-   */
-  LRUCache.prototype.get = function(key) {
-    key = key + '';
-    if (!this.cache[key]) {
-      return;
-    }
-    delete this.useIndex[this.useReverse[key]];
-
-    this._makeMostRecent(key);
-    return this.cache[key];
-  };
-
   LRUCache.prototype._makeMostRecent = function (key) {
+    var current = this.useReverse[key];
+    if (current === this.mostRecent) {
+      return;
+    } else if (current) {
+      delete this.useIndex[current];
+    }
+
     this.mostRecent += 1;
     var newIndex = this.mostRecent;
     this.useIndex[newIndex] = key;


### PR DESCRIPTION
This PR adds a "Least Recently Used Cache" for tracking PFonts, fixing the memory that some users are seeing when using many different font sizes (especially having random or ever-increasing font-sizes).

I set the cache size to 100, but there may be a better size.

Also, I created tests for the LRUCache, but it didn't seem like there was a good place to put them (all the tests I saw are just PDE files). So I put them in a new directory, along with a `package.json` to get required test libs.
If it's desired, I can just remove the directory -- the code for the LRUCache is already copied into `processing.js`.

## Validating that this fixes the memory leak
This is somewhat involved.
1. Grab [Khan/live-editor](https://github.com/Khan/live-editor) and follow the installation instructions.
2. from live-editor, cd into `external/processing-js`, and `git pull https://github.com/jaredly/processing-js#add-lru-cache` and then `make`
3. from the `live-editor` directory, run `npm run build`
4. start a simple http server (via `npm install -g http-server` or sth) in the live-editor directory
5. open firefox to that server (e.g. http://localhsot:8081)
6. paste the following code into the editor, and verify that the firefox process doesn't run out of control (on my MBP it would go up to about 1.6G, and then down to 900M, and oscillate a bit)

```js
var x = 50;
var dx = 1;
var f = 1;
var draw = function() {
    x += dx;
    f += 0.1;
    if (x > 300) {
        dx = -1;
        x = 300;
    }
    if (x < 50) {
        x = 50;
        dx = 1;
    }
    rect(0, 0, 40, x);
    textSize(f);
};
```
The moving rectangle is so that you can visually verify that the editor hasn't crashed or anything.

Without this fix, the above code would cause the firefox process to grow indefinitely (again on my MBP it was up to 3.5G memory in 15 or 20 seconds)