### PR TITLE
Add message-based trigger for full screen log

### DIFF
--- a/processing.js
+++ b/processing.js
@@ -19715,7 +19715,8 @@
               if (height < 0) {
                 height = 0;
               } else if (height + resizerHeight > viewHeight) {
-                height = viewHeight - resizerHeight;
+                // subtract resizer height and bottom padding
+                height = viewHeight - resizerHeight - 5;
               }
 
               containerStyle.height = height / viewHeight * 100 + "%";
@@ -19792,6 +19793,11 @@
           docElem.insertBefore(container, docElem.firstChild);
 
           tinylogLite[log] = function(message) {
+            // If we intercept special message, display full-screen log
+            if (message === "FULLSCREENLOG") {
+              setContainerHeight(Infinity);
+              return;
+            }
             if (messages === logLimit) {
               output.removeChild(output.firstChild);
             } else {


### PR DESCRIPTION
In live-editor, I am adding an option called logFullScreen that displays the log at start and displays it at full screen. (See PR at https://github.com/Khan/live-editor/pull/700)

I looked into various ways of accomplishing this in processing.js. 

This proposal modifies the internal logger so that if it receives the message ("LOGFULLSCREEN"), then it sets the container height to maximum. This approach is minimally obtrusive in that I don't have to make any code changes to the Processing constructor or related constructors like Sketch. 

The drawback of this technique is that it doesn't remember its original height, so that if the user does press the x and then restarts, the log will be back at the bottom. That doesn't bother me terribly, as the user will have seen the possibility of it being full-screen and can resize it back.

If this seems too hacky, then I can go back down the path of the constructors. It's a bit tricky due to the order of operations of when things get defined and constructed, but I'm sure there are more possibilities. 
